### PR TITLE
BUG: Verifies type of `rules_to_add` for a `Rule_Collection`

### DIFF
--- a/gmail_rules/actions/rule_collection.py
+++ b/gmail_rules/actions/rule_collection.py
@@ -66,11 +66,13 @@ class Rule_Collection:
             raise TypeError(f"rule_to_add is not of type Rule or a list of Rules.  It is of type {type(rules_to_add)}")
 
         for rule in rules_to_add:
+            if not isinstance(rule, _R.Rule):
+                raise TypeError(f"rule is not of type Rule.  It is of type {type(rule)}")
             if rule.name in self.rules_dict:
                 raise KeyError(f"{rule.name} is already in the collection of rules.  Use update_rule() to change the value of this rule")
-            else:
-                self.rules_list.append(rule)
-                self.rules_dict[rule.name] = rule
+
+            self.rules_list.append(rule)
+            self.rules_dict[rule.name] = rule
 
     def build_final_string(self, additional_comment: str = None):
         final_string = ""

--- a/tests/test_actions/test_rule_collection.py
+++ b/tests/test_actions/test_rule_collection.py
@@ -54,3 +54,29 @@ class TestRuleCollection:
 
         assert self.collection_1[rule_2.name] is rule_2
         assert self.collection_1[rule_2.name].final_rule_str == rule_2_str
+
+    def test_adding_multiple_rules_to_collection(self):
+        """Test adding multiple rules to the collection at once
+        """
+        new_rule_1 = _R.Rule(["mango@gmail.com"], rule_name="Testing")
+        new_rule_1.add_attribute("subject", "[IMPORTANT] Mangos for Sale")
+        new_rule_2 = _R.Copy_To("fruits", ["banana@gmail.com", "kiwi@gmail.com"])
+        new_rule_2.add_attribute("subject", "FRUIT")
+
+        self.collection_1.add_rule([new_rule_1, new_rule_2])
+
+        assert new_rule_1 in self.collection_1.rules_dict.values()
+        assert new_rule_2 in self.collection_1.rules_dict.values()
+
+    def test_adding_multiple_rules_error_raised(self):
+        """Test adding multiple rules to the collection but one of the rules should raise an error
+        """
+        new_rule_1 = _R.Rule(["mangos@gmail.com"], rule_name="Testing Again")
+        new_rule_1.add_attribute("subject", "[IMPORTANT] Mangos for Sale")
+        new_rule_2 = _R.Copy_To("more fruits", ["bananas@gmail.com", "kiwi@gmail.com"])
+        new_rule_2.add_attribute("subject", "FRUIT")
+
+        not_a_rule = "cheese"
+
+        with pytest.raises(TypeError):
+            self.collection_1.add_rule([new_rule_1, new_rule_2, not_a_rule])


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request verifies the type of each element in `rules_to_add` to make sure that everything being added to a `Rule_Collection` is of a valid type.

## Related Issues

Related to #21
Fixes #21

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] Documentation (added documentation or related to docs)

## How Has This Been Tested?

Added tests in `test_rule_collection.py` to ensure that an error is raised when a Non-`Rule` type is added to a `Rule_Collection`
- [X] tests/test_actions/test_rule_colletion.py > `TestRuleCollection` > `test_adding_multiple_rules_to_collection()`
- [X] tests/test_actions/test_rule_colletion.py > `TestRuleCollection` > `test_adding_multiple_rules_error_raised()`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings