### PR TITLE
FEAT: Adjust how a `Rule_Collection` adds multiple rules at once

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Please delete options that are not relevant.
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
-- [ ] Test A
+- [ ] Test A (Example: `tests/test_actions/test_rule_collection.py` --> `TestRuleCollection.test_adding_multiple_rules_to_collection()`)
 - [ ] Test B
 
 ## Checklist:

--- a/gmail_rules/actions/rule_collection.py
+++ b/gmail_rules/actions/rule_collection.py
@@ -53,26 +53,21 @@ class Rule_Collection:
         return self.build_final_string()
 
     #### TODO: FIX THIS TO ACCOUNT FOR INDENTING ####
-    def add_rule(self, rules_to_add: _R.Rule | list[_R.Rule]):
-        try:
-            if isinstance(rules_to_add, _R.Rule):
-                rules_to_add = [rules_to_add]
-            elif isinstance(rules_to_add[0], _R.Rule):
-                pass
-            else:
-                raise TypeError(f"rule_to_add is not of type Rule or a list of Rules.  It is of type {type(rules_to_add)}")
+    def add_rule(self, rule_to_add: _R.Rule):
+        if not isinstance(rule_to_add, _R.Rule):
+            raise TypeError(f"rule_to_add is not of type Rule.  It is of type {type(rule_to_add)}")
+        if rule_to_add.name in self.rules_dict:
+            raise KeyError(f"{rule_to_add.name} is already in the collection of rules.  Use update_rule() to change the value of this rule")
 
-        except TypeError:
-            raise TypeError(f"rule_to_add is not of type Rule or a list of Rules.  It is of type {type(rules_to_add)}")
+        self.rules_dict[rule_to_add.name] = rule_to_add
+        self.rules_list.append(rule_to_add)
+    
+    def add_rules(self, rules_to_add: list[_R.Rule]):
+        if not hasattr(rules_to_add, "__iter__"):
+            raise TypeError(f"rules_to_add needs to be an iterable, but currently is of type {type(rules_to_add)}")
 
         for rule in rules_to_add:
-            if not isinstance(rule, _R.Rule):
-                raise TypeError(f"rule is not of type Rule.  It is of type {type(rule)}")
-            if rule.name in self.rules_dict:
-                raise KeyError(f"{rule.name} is already in the collection of rules.  Use update_rule() to change the value of this rule")
-
-            self.rules_list.append(rule)
-            self.rules_dict[rule.name] = rule
+            self.add_rule(rule)
 
     def build_final_string(self, additional_comment: str = None):
         final_string = ""

--- a/tests/test_actions/test_rule_collection.py
+++ b/tests/test_actions/test_rule_collection.py
@@ -54,6 +54,16 @@ class TestRuleCollection:
 
         assert self.collection_1[rule_2.name] is rule_2
         assert self.collection_1[rule_2.name].final_rule_str == rule_2_str
+    
+    def test_add_rule_with_same_name_to_collection(self):
+        """Ensure a KeyError is raised when rules with the same name are added to a collection
+        """
+        rule_1 = _R.Rule(rule_name="Duplicate Rule", rule_defaults={"subject": "This can be added to the collection"})
+        rule_2 = _R.Rule(rule_name="Duplicate Rule", rule_defaults={"subject": "This should not be added"})
+
+        self.collection_1.add_rule(rule_1)
+        with pytest.raises(KeyError):
+            self.collection_1.add_rule(rule_2)
 
     def test_adding_multiple_rules_to_collection(self):
         """Test adding multiple rules to the collection at once
@@ -63,7 +73,7 @@ class TestRuleCollection:
         new_rule_2 = _R.Copy_To("fruits", ["banana@gmail.com", "kiwi@gmail.com"])
         new_rule_2.add_attribute("subject", "FRUIT")
 
-        self.collection_1.add_rule([new_rule_1, new_rule_2])
+        self.collection_1.add_rules([new_rule_1, new_rule_2])
 
         assert new_rule_1 in self.collection_1.rules_dict.values()
         assert new_rule_2 in self.collection_1.rules_dict.values()
@@ -79,4 +89,4 @@ class TestRuleCollection:
         not_a_rule = "cheese"
 
         with pytest.raises(TypeError):
-            self.collection_1.add_rule([new_rule_1, new_rule_2, not_a_rule])
+            self.collection_1.add_rules([new_rule_1, new_rule_2, not_a_rule])


### PR DESCRIPTION
# Pull Request Template

## Description

Separates `Rule_Collection.add_rule()` into two functions `Rule_Collection.add_rule()` and `Rule_Collection.add_rules()` to ensure that the inputs to each are the appropriate kind.

## Related Issues

Related to #25
Fixes #25

## Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a few test cases to test this code.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings