### PR TITLE
FEAT: Add Multiple Rule Attributes at a Time

### DIFF
--- a/gmail_rules/actions/rule_collection.py
+++ b/gmail_rules/actions/rule_collection.py
@@ -42,7 +42,7 @@ class Rule_Collection:
         return self.rules_dict[name]
 
     @property
-    def final_string(self):
+    def final_string(self) -> str:
         """Generates the final string representation of a collection of rules
 
         Returns
@@ -53,7 +53,21 @@ class Rule_Collection:
         return self.build_final_string()
 
     #### TODO: FIX THIS TO ACCOUNT FOR INDENTING ####
-    def add_rule(self, rule_to_add: _R.Rule):
+    def add_rule(self, rule_to_add: _R.Rule) -> None:
+        """Add a :obj:`Rule` to a `Rule_Collection`
+
+        Parameters
+        ----------
+        rule_to_add : :obj:`Rule`
+            This is the rule that should be added to this collection
+
+        Raises
+        ------
+        TypeError
+            Raises a `TypeError` if `rule_to_add` is not of type :obj:`Rule`
+        KeyError
+            Raises a `KeyError` if `rule_to_add` is already in the :obj:`Rule_Collection`
+        """
         if not isinstance(rule_to_add, _R.Rule):
             raise TypeError(f"rule_to_add is not of type Rule.  It is of type {type(rule_to_add)}")
         if rule_to_add.name in self.rules_dict:
@@ -62,21 +76,45 @@ class Rule_Collection:
         self.rules_dict[rule_to_add.name] = rule_to_add
         self.rules_list.append(rule_to_add)
     
-    def add_rules(self, rules_to_add: list[_R.Rule]):
+    def add_rules(self, rules_to_add: list[_R.Rule]) -> None:
+        """Add multiple :obj:`Rule` objects to the collection at once
+
+        Parameters
+        ----------
+        rules_to_add : list[_R.Rule]
+            Iterable that contains all of the :obj:`Rule`s to be added
+
+        Raises
+        ------
+        TypeError
+            Raises a `TypeError` if `rules_to_add` is not an iterable datatype
+        """
         if not hasattr(rules_to_add, "__iter__"):
             raise TypeError(f"rules_to_add needs to be an iterable, but currently is of type {type(rules_to_add)}")
 
         for rule in rules_to_add:
             self.add_rule(rule)
 
-    def build_final_string(self, additional_comment: str = None):
+    def build_final_string(self, additional_comment: str = None) -> str:
+        """Builds the final properly formatted collection of rules
+
+        Parameters
+        ----------
+        additional_comment : str, optional
+            Adds a final comment above the entire rule string, by default None
+
+        Returns
+        -------
+        str
+            final string representing all of the :obj:`Rule`s in the collection
+        """
         final_string = ""
+
+        if additional_comment is not None:
+            final_string += f"{_hp.add_xml_comment(additional_comment)}"
 
         for rule in reversed(self.rules_list):      ## MAYBE REMOVE REVERSAL
             final_string += f"\n\n{rule.build_rule()}"
-
-        if additional_comment is not None:
-            final_string = f"{_hp.add_xml_comment(additional_comment)}"
 
         return final_string
     #### TODO: FIX THIS TO ACCOUNT FOR INDENTING ^^^ ####

--- a/gmail_rules/actions/rule_collection.py
+++ b/gmail_rules/actions/rule_collection.py
@@ -101,7 +101,7 @@ class Rule_Collection:
         Parameters
         ----------
         additional_comment : str, optional
-            Adds a final comment above the entire rule string, by default None
+            Adds a final comment above the entire rule string, by default `None`
 
         Returns
         -------

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -145,9 +145,9 @@ class Rule:
         Parameters
         ----------
         elements_input : `list`
-            This is a list of items that should be concatenated together.
+            This is a list of items that should be concatenated together
         separator : `str`, default = `" OR "`, optional
-            This is the string that will be used to separate individual elements.
+            This is the string that will be used to separate individual elements, by default `" OR "`
 
         Returns
         -------
@@ -202,7 +202,7 @@ class Rule:
         value : str
             Value of the attribute
         is_custom_attribute : bool, optional
-            Defines whether the attribute being added is custom (use with caution), default = `False`
+            Defines whether the attribute being added is custom (use with caution), by default `False`
         """
         if name in self.rule_attributes:
             ## Raise Error when rule already contains a value for this attribute
@@ -219,6 +219,27 @@ class Rule:
             raise KeyError(f"{name} is not a valid filter attribute.  Check for typos")
 
         self.rule_attributes[name] = value
+
+    def add_attributes(self, attributes_to_add: dict) -> None:
+        """Add multiple attributes to a `Rule`
+
+        Parameters
+        ----------
+        attributes_to_add : dict
+            Dictionary where key is the name of the attribute to add (`str`)
+            and its value (`str`) is the value of the attribute to add corresponding
+            to that key
+
+        Raises
+        ------
+        TypeError
+            Raises a `TypeError` if `attributes_to_add` is not a dictionary
+        """
+        if not isinstance(attributes_to_add, dict):
+            raise TypeError(f"attributes_to_add needs to be a dictionary, but currently it is of type {type(attributes_to_add)}")
+
+        for attribute_name, attribute_value in attributes_to_add.items():
+            self.add_attribute(attribute_name, attribute_value)
 
     def build_rule(self) -> str:
         """

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -83,6 +83,7 @@ class Rule:
         Returns
         -------
         rule_attribute_xmls : `dict`
+            Dictionary where keys are the attribute and values are the xml representation of the attribute
         """
         rule_attributes_xmls = {}
         for attribute_name, attribute_value in self.rule_attributes.items():
@@ -92,11 +93,12 @@ class Rule:
 
     @property
     def rule_attributes_xmls_str(self) -> str:
-        """Converts `dict` of rule attributes into ordered `str` for use in final xml
+        """Converts :obj:`dict` of rule attributes into ordered `str` for use in final xml
 
         Returns
         -------
         rule_attribute_xmls_str : `str`
+            :obj:`str` representing this :obj:`Rule` as an xml
         """
         rule_attributes_xmls_str = ""
         current_rule_xmls = self.rule_attributes_xmls
@@ -109,7 +111,13 @@ class Rule:
 
     @property
     def final_rule_str(self) -> str:
-        """This is the final `str` that can be copied and pasted into an xml to define the rule"""
+        """This is the final `str` that can be copied and pasted into an xml to define the rule
+
+        Returns
+        -------
+        str
+            `str` representing the entire rule in xml format
+        """
         return self.build_rule()
 
     def _modify_possible_attributes(self, new_attribute: str) -> None:
@@ -124,10 +132,21 @@ class Rule:
         self._possible_attributes = frozenset(self._attribute_order)
 
     def flatten_list(self, list_to_flatten: list | list[list]) -> list:
-        """
+        """Converts a list of lists into a single flat list
+
         This function takes a `list` (of potentially nested lists) and recursively
         flattens the list so that it is just a single list of elements that are not
         of type `list`
+
+        Parameters
+        ----------
+        list_to_flatten : `list` or `list[list]`
+            Input `list` (or list of lists) to be flattened
+        
+        Returns
+        -------
+        list
+            Returns a final flat list that does not contain any nested lists
         """
         if list_to_flatten == []:
             return list_to_flatten


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the ability to add multiple rule attributes at a time.  Adjusts the `Rule` object in `gmail_rules.rules.rule.py`.

## Related Issues

Related to #2 
Fixes #2 

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Documentation (added documentation or related to docs)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested the changes on a variety of sample cases.

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings