### PR TITLE
FEAT: Allow Rules to have Multiple Labels

### DIFF
--- a/gmail_rules/actions/rule_collection.py
+++ b/gmail_rules/actions/rule_collection.py
@@ -53,21 +53,58 @@ class Rule_Collection:
         return self.build_final_string()
 
     #### TODO: FIX THIS TO ACCOUNT FOR INDENTING ####
-    def add_rule(self, rule_to_add: _R.Rule):
-        if not isinstance(rule_to_add, _R.Rule):
-            raise TypeError(f"rule_to_add is not of type Rule.  It is of type {type(rule_to_add)}")
-        if rule_to_add.name in self.rules_dict:
-            raise KeyError(f"{rule_to_add.name} is already in the collection of rules.  Use update_rule() to change the value of this rule")
+    def add_rules(self, rules_to_add: _R.Rule | list | tuple | set | frozenset | dict) -> None:
+        """Adds :obj:`Rule`s to a :obj:`Rule_Collection`
 
-        self.rules_dict[rule_to_add.name] = rule_to_add
-        self.rules_list.append(rule_to_add)
-    
-    def add_rules(self, rules_to_add: list[_R.Rule]):
-        if not hasattr(rules_to_add, "__iter__"):
+        Parameters
+        ----------
+        rules_to_add : :obj:`Rule` or list or tuple or set or frozenset or dict
+            The :obj:`Rule` (or :obj:`Rule`s) that should be added to the :obj:`Rule_Collection`
+
+        Raises
+        ------
+        KeyError
+            Raises a `KeyError` when a certain rule is already in the collection
+        TypeError
+            Raises a `TypeError` when a rule is not of type :obj:`Rule`
+        TypeError
+            Raises a `TypeError` if a rule is not an iterable of :obj:`Rule`s
+        """
+        if isinstance(rules_to_add, _R.Rule):
+            if rules_to_add.name in self.rules_dict:
+                raise KeyError(f"{rules_to_add.name} is already in the collection of rules.  Use update_rule() to change the value of this rule")
+
+            self.rules_dict[rules_to_add.name] = rules_to_add
+            self.rules_list.append(rules_to_add)
+
+        elif type(rules_to_add) in _hp.ITERABLE_DATA_TYPES:
+            for rule in rules_to_add:
+                self.add_rules(rule)
+
+        elif type(rules_to_add) not in _hp.ITERABLE_DATA_TYPES:
             raise TypeError(f"rules_to_add needs to be an iterable, but currently is of type {type(rules_to_add)}")
 
-        for rule in rules_to_add:
-            self.add_rule(rule)
+        else:
+            raise TypeError(f"rules_to_add is not of type Rule.  It is of type {type(rules_to_add)}")
+
+    def add_rule(self, rule_to_add: _R.Rule) -> None:
+        """Alias for :obj:`Rule_Collection.add_rules()`.  Adds :obj:`Rule`s to a :obj:`Rule_Collection`
+
+        Parameters
+        ----------
+        rules_to_add : list or tuple or set or frozenset or dict
+            The :obj:`Rule`s that should be added to the :obj:`Rule_Collection`
+
+        Raises
+        ------
+        KeyError
+            Raises a `KeyError` when a certain rule is already in the collection
+        TypeError
+            Raises a `TypeError` when a rule is not of type :obj:`Rule`
+        TypeError
+            Raises a `TypeError` if a rule is not an iterable of :obj:`Rule`s
+        """
+        self.add_rules(rule_to_add)
 
     def build_final_string(self, additional_comment: str = None):
         final_string = ""

--- a/gmail_rules/rules/copy_to.py
+++ b/gmail_rules/rules/copy_to.py
@@ -7,44 +7,38 @@ __all__ = ["Copy_To"]
 
 @set_module('gmail_rules.rules')
 class Copy_To(_Rule):
-    """Copy_To rule object which is a sub-class of :obj:`Rule`
-
-    Parameters
-    ----------
-    rule_label : `str`
-        This is the label that should be applied to emails that meet
-        this rule's criteria
-    list_of_emails : `list`
-        This is a list of email addresses that the mail rule should be
-        applied to.
-    rule_defaults : `dict`, optional
-        This is a dictionary containing default rule attributes
+    """:obj:`Copy_To` rule object which is a sub-class of :obj:`Rule`
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
-        """Initialize a Copy_To rule object which is a subclass of :obj:`Rule`
+    def __init__(self, rule_label: str | list, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
+        """Initialize a :obj:`Copy_To` rule object which is a subclass of :obj:`Rule`
 
         Parameters
         ----------
-        rule_label : `str`
+        rule_label : `str` or `list`
             This is the label that should be applied to emails that meet
             this rule's criteria
-        list_of_emails : `list`
+        list_of_emails : `list`, optional
             This is a list of email addresses that the mail rule should be
-            applied to.
+            applied to
         rule_defaults : `dict`, optional
             This is a dictionary containing default rule attributes
         """
         if rule_name == "":
-            rule_name = f"COPY TO: {rule_label}"
+            rule_name = "COPY TO: "
+
+            if isinstance(rule_label, str):
+                rule_name += f"{rule_label}"
+
+            elif type(rule_label) in _hp.ITERABLE_DATA_TYPES:
+                for label in rule_label:
+                    rule_name += f"{label} | "
+                rule_name = rule_name[:-3]
 
         rule_defaults.update(shouldNeverSpam = "true")
         ## Add rule-type specific flags to the flags dictionary
 
         super().__init__(list_of_emails, rule_defaults, rule_name)
 
-        self.rule_label: str = rule_label
-        """This is the label that will be applied to all of the emails with this rule"""
-
-        self.add_attribute("label", self.rule_label)
-        ## Add the labeling attribute to the mail rule
+        self.add_labels(rule_label)
+        ## Add the label attribute to the mail rule

--- a/gmail_rules/rules/copy_to.py
+++ b/gmail_rules/rules/copy_to.py
@@ -21,7 +21,7 @@ class Copy_To(_Rule):
         This is a dictionary containing default rule attributes
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}) -> None:
+    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
         """Initialize a Copy_To rule object which is a subclass of :obj:`Rule`
 
         Parameters
@@ -35,7 +35,9 @@ class Copy_To(_Rule):
         rule_defaults : `dict`, optional
             This is a dictionary containing default rule attributes
         """
-        rule_name = f"COPY TO: {rule_label}"
+        if rule_name == "":
+            rule_name = f"COPY TO: {rule_label}"
+
         rule_defaults.update(shouldNeverSpam = "true")
         ## Add rule-type specific flags to the flags dictionary
 

--- a/gmail_rules/rules/move_to.py
+++ b/gmail_rules/rules/move_to.py
@@ -7,46 +7,40 @@ __all__ = ["Move_To"]
 
 @set_module('gmail_rules.rules')
 class Move_To(_Rule):
-    """Move_To rule object which is a sub-class of :obj:`Rule`
-
-    Parameters
-    ----------
-    rule_label : `str`
-        This is the label that should be applied to emails that meet
-        this rule's criteria
-    list_of_emails : `list`
-        This is a list of email addresses that the mail rule should be
-        applied to.
-    rule_defaults : `dict`, optional
-        This is a dictionary containing default rule attributes
+    """:obj:`Move_To` rule object which is a sub-class of :obj:`Rule`
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
-        """Initialize a Move_To rule object which is a subclass of :obj:`Rule`
+    def __init__(self, rule_label: str | list, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
+        """Initialize a :obj:`Move_To` rule object which is a subclass of :obj:`Rule`
 
         Parameters
         ----------
-        rule_label : `str`
+        rule_label : `str` or `list`
             This is the label that should be applied to emails that meet
             this rule's criteria
-        list_of_emails : `list`
+        list_of_emails : `list`, optional
             This is a list of email addresses that the mail rule should be
-            applied to.
+            applied to
         rule_defaults : `dict`, optional
             This is a dictionary containing default rule attributes
         rule_name : `str`, optional
             This is the name of the specific rule
         """
         if rule_name == "":
-            rule_name = f"MOVE TO: {rule_label}"
+            rule_name = "MOVE TO: "
+
+            if isinstance(rule_label, str):
+                rule_name += f"{rule_label}"
+
+            elif type(rule_label) in _hp.ITERABLE_DATA_TYPES:
+                for label in rule_label:
+                    rule_name += f"{label} | "
+                rule_name = rule_name[:-3]
 
         rule_defaults.update(shouldNeverSpam = "true", shouldArchive = "true")
         ## Add rule-type specific flags to the flags dictionary
 
         super().__init__(list_of_emails, rule_defaults, rule_name)
 
-        self.rule_label: str = rule_label
-        """This is the label that will be applied to all of the emails with this rule"""
-
-        self.add_attribute("label", self.rule_label)
-        ## Add the labeling attribute to the mail rule
+        self.add_labels(rule_label)
+        ## Add the label attribute to the mail rule

--- a/gmail_rules/rules/move_to.py
+++ b/gmail_rules/rules/move_to.py
@@ -21,7 +21,7 @@ class Move_To(_Rule):
         This is a dictionary containing default rule attributes
     """
 
-    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}) -> None:
+    def __init__(self, rule_label: str, list_of_emails: list = [], rule_defaults: dict = {}, rule_name: str = "") -> None:
         """Initialize a Move_To rule object which is a subclass of :obj:`Rule`
 
         Parameters
@@ -34,8 +34,12 @@ class Move_To(_Rule):
             applied to.
         rule_defaults : `dict`, optional
             This is a dictionary containing default rule attributes
+        rule_name : `str`, optional
+            This is the name of the specific rule
         """
-        rule_name = f"MOVE TO: {rule_label}"
+        if rule_name == "":
+            rule_name = f"MOVE TO: {rule_label}"
+
         rule_defaults.update(shouldNeverSpam = "true", shouldArchive = "true")
         ## Add rule-type specific flags to the flags dictionary
 

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -290,10 +290,15 @@ class Rule:
 
         else:
             for label in self.labels:
-                rule_comment = _hp.add_xml_comment(f'{self.name}' if len(self.labels) == 1 else f'{self.name} ({label})')
+                rule_comment = _hp.add_xml_comment(self.name if len(self.labels) == 1 else f'{self.name} ({label})')
                 final_rule += f"{rule_comment}\n{self.rule_header}{self.xml_format_rule_attribute('label', label)}{self.rule_attributes_xmls_str}{self.rule_footer}\n"
 
             final_rule = final_rule[:-1]
+
+            if len(self.labels) > 1:
+                starting_comment = f"{_hp.add_xml_comment(f'START --- {self.name} --- START')}\n"
+                ending_comment = f"\n{_hp.add_xml_comment(f'END --- {self.name} --- END')}"
+                final_rule = f"{starting_comment}{final_rule}{ending_comment}"
 
         final_rule = final_rule.expandtabs(_hp.TAB_SPACING)
 

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -202,7 +202,9 @@ class Rule:
         value : str
             Value of the attribute
         is_custom_attribute : bool, optional
-            Defines whether the attribute being added is custom (use with caution), default = `False`
+            Defines whether the attribute being added is custom (use with caution), default = `False`.
+            Use this with caution, as the mail rule interpreter may not be able to parse a rule with
+            a custom attribute
         """
         if name in self.rule_attributes:
             ## Raise Error when rule already contains a value for this attribute

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -208,6 +208,13 @@ class Rule:
             Defines whether the attribute being added is custom (use with caution), default = `False`.
             Use this with caution, as the mail rule interpreter may not be able to parse a rule with
             a custom attribute
+
+        Raises
+        ------
+        KeyError
+            Raises a `KeyError` when an attribute has already been defined for this rule
+        KeyError
+            Raises a `KeyError` if an attribute is not valid
         """
         if name in self.rule_attributes:
             ## Raise Error when rule already contains a value for this attribute
@@ -231,22 +238,43 @@ class Rule:
 
         self.rule_attributes[name] = value
 
-    def add_label(self, label: str) -> None:
-        if isinstance(label, str):
-            self.labels.append(label)
-        elif type(label) in _hp.ITERABLE_DATA_TYPES:
-            self.add_labels(label)
+    def add_labels(self, labels: str | list | tuple | set | frozenset | dict) -> None:
+        """Adds labels to the mail rule
+
+        Parameters
+        ----------
+        labels : list | tuple | set | frozenset | dict
+            The label (or labels) to be added to the rule
+
+        Raises
+        ------
+        TypeError
+            Raises a `TypeError` if the label is not a valid type
+        """
+        if isinstance(labels, str):
+            self.labels.append(labels)
+
+        elif type(labels) in _hp.ITERABLE_DATA_TYPES:
+            for label in labels:
+                self.add_label(label)
+
         else:
             raise TypeError(f"The label being added is not a string.  It is of type {type(label)}")
 
-    def add_labels(self, labels: list | tuple | set | frozenset | dict) -> None:
-        if type(labels) in _hp.ITERABLE_DATA_TYPES:
-            for label in labels:
-                self.add_label(label)
-        elif isinstance(labels, str):
-            self.add_label(labels)
-        else:
-            raise TypeError(f"The labels being added are not in an iterable datatype.  They are of type {type(labels)}")
+    def add_label(self, label: str) -> None:
+        """Alias for :obj:`Rule.add_label()`.  Adds labels to the mail rule
+
+        Parameters
+        ----------
+        labels : list | tuple | set | frozenset | dict
+            The label (or labels) to be added to the rule
+
+        Raises
+        ------
+        TypeError
+            Raises a `TypeError` if the label is not a valid type
+        """
+        self.add_labels(label)
 
     def build_rule(self) -> str:
         """
@@ -262,7 +290,6 @@ class Rule:
 
         else:
             for label in self.labels:
-                print(label)
                 rule_comment = _hp.add_xml_comment(f'{self.name}' if len(self.labels) == 1 else f'{self.name} ({label})')
                 final_rule += f"{rule_comment}\n{self.rule_header}{self.xml_format_rule_attribute('label', label)}{self.rule_attributes_xmls_str}{self.rule_footer}\n"
 

--- a/gmail_rules/rules/rule.py
+++ b/gmail_rules/rules/rule.py
@@ -296,7 +296,7 @@ class Rule:
 
         elif type(labels) in _hp.ITERABLE_DATA_TYPES:
             for label in labels:
-                self.add_label(label)
+                self.add_labels(label)
 
         else:
             raise TypeError(f"The label being added is not a string.  It is of type {type(label)}")

--- a/gmail_rules/utils/helpers.py
+++ b/gmail_rules/utils/helpers.py
@@ -1,7 +1,9 @@
 import textwrap
-import os
 
-TAB_SPACING = 4
+TAB_SPACING : int = 4
+"""Default amount of spaces used instead of a tab (`\\t`)"""
+ITERABLE_DATA_TYPES : set = {list, tuple, set, frozenset, dict}
+"""Iterable data types that can store multiple instances of other objects\n\nContains: `list`, `tuple`, `set`, `frozenset`, `dict`"""
 
 def add_xml_comment(comment_text: str) -> str:
     """Add an xml comment to a string (does not include for newlines `"\\n"`)

--- a/tests/test_actions/test_rule_collection.py
+++ b/tests/test_actions/test_rule_collection.py
@@ -8,7 +8,7 @@ import gmail_rules.utils.helpers as _hp
 class TestRuleCollection:
 
     collection_1 : Rule_Collection = None
-    rule_1 = _R.Copy_To("rule_1", ["1"])
+    rule_1 = _R.Copy_To(rule_label="label_1", list_of_emails=["test_1@gmail.com"])
 
     def test_rule_collection_definition(self) -> None:
         """Test defining a new rule_collection
@@ -25,7 +25,7 @@ class TestRuleCollection:
         self.collection_1.add_rule(self.rule_1)
 
         ## CORRECT RULE STRING ##
-        rule_1_str_1 = "<!-- COPY TO: rule_1 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: rule_1</title>\n\t<content></content>\n\t<apps:property name='label' value='rule_1'/>\n\t<apps:property name='from' value='1'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
+        rule_1_str_1 = "<!-- COPY TO: label_1 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: label_1</title>\n\t<content></content>\n\t<apps:property name='label' value='label_1'/>\n\t<apps:property name='from' value='test_1@gmail.com'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
         assert self.collection_1[self.rule_1.name] is self.rule_1
         assert self.collection_1[self.rule_1.name].final_rule_str == rule_1_str_1
@@ -37,7 +37,7 @@ class TestRuleCollection:
         self.rule_1.add_attribute("subject", "233")
 
         ## CORRECT RULE STRING ##
-        rule_1_str_2 = "<!-- COPY TO: rule_1 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: rule_1</title>\n\t<content></content>\n\t<apps:property name='label' value='rule_1'/>\n\t<apps:property name='from' value='1'/>\n\t<apps:property name='subject' value='233'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
+        rule_1_str_2 = "<!-- COPY TO: label_1 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: label_1</title>\n\t<content></content>\n\t<apps:property name='label' value='label_1'/>\n\t<apps:property name='from' value='test_1@gmail.com'/>\n\t<apps:property name='subject' value='233'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
         assert self.collection_1[self.rule_1.name] is self.rule_1
         assert self.collection_1[self.rule_1.name].final_rule_str == rule_1_str_2
@@ -46,11 +46,11 @@ class TestRuleCollection:
         """Test having more than one rule in a collection
         """
         ## ADD RULE_2
-        rule_2 = _R.Copy_To("rule_2", ["Beijing", "Shanghai"])
+        rule_2 = _R.Copy_To(rule_label="label_2", list_of_emails=["Beijing@gmail.com", "Shanghai@gmail.com"])
         self.collection_1.add_rule(rule_2)
 
         ## CORRECT RULE_2 STRING ##
-        rule_2_str = "<!-- COPY TO: rule_2 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: rule_2</title>\n\t<content></content>\n\t<apps:property name='label' value='rule_2'/>\n\t<apps:property name='from' value='Beijing OR Shanghai'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
+        rule_2_str = "<!-- COPY TO: label_2 -->\n<entry>\n\t<category term='filter'></category>\n\t<title>COPY TO: label_2</title>\n\t<content></content>\n\t<apps:property name='label' value='label_2'/>\n\t<apps:property name='from' value='Beijing@gmail.com OR Shanghai@gmail.com'/>\n\t<apps:property name='shouldNeverSpam' value='true'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
         assert self.collection_1[rule_2.name] is rule_2
         assert self.collection_1[rule_2.name].final_rule_str == rule_2_str
@@ -68,9 +68,9 @@ class TestRuleCollection:
     def test_adding_multiple_rules_to_collection(self):
         """Test adding multiple rules to the collection at once
         """
-        new_rule_1 = _R.Rule(["mango@gmail.com"], rule_name="Testing")
+        new_rule_1 = _R.Rule(list_of_emails=["mango@gmail.com"], rule_name="Testing")
         new_rule_1.add_attribute("subject", "[IMPORTANT] Mangos for Sale")
-        new_rule_2 = _R.Copy_To("fruits", ["banana@gmail.com", "kiwi@gmail.com"])
+        new_rule_2 = _R.Copy_To(rule_label="fruits", list_of_emails=["banana@gmail.com", "kiwi@gmail.com"])
         new_rule_2.add_attribute("subject", "FRUIT")
 
         self.collection_1.add_rules([new_rule_1, new_rule_2])

--- a/tests/test_rules/test_rule.py
+++ b/tests/test_rules/test_rule.py
@@ -3,13 +3,23 @@ import pytest
 from gmail_rules.rules.rule import Rule
 import gmail_rules.utils.helpers as _hp
 
+from gmail_rules.rules.copy_to import Copy_To
+from gmail_rules.rules.move_to import Move_To
+
+
 class TestRule:
 
+    # @pytest.mark.parametrize("rule", [Rule(), Copy_To("label_1"), Move_To("label_1")], ids=["Rule", "Copy_To", "Move_To"])
+    # def test_rule_definition(self, rule):
     def test_rule_definition(self):
+        """Test creating/defining a new :obj:`Rule`
+        """
         new_rule = Rule()
         assert isinstance(new_rule, Rule)
 
     def test_add_rule_attribute(self):
+        """Test adding attributes to a :obj:`Rule` in the correct order
+        """
         correct_rule = "<!-- Mail Filter -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
         new_rule = Rule()
@@ -21,6 +31,8 @@ class TestRule:
         assert new_rule.final_rule_str == correct_rule
 
     def test_add_rule_attributes_unordered(self):
+        """Test adding a attributes to a :obj:`Rule` in a random order
+        """
         correct_rule = "<!-- Mail Filter -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
         new_rule = Rule()
@@ -32,9 +44,25 @@ class TestRule:
         assert new_rule.final_rule_str == correct_rule
 
     def test_rule_with_email_addresses(self):
+        """Test creating a rule that applies to a specified set of email addresses
+        """
         correct_rule = "<!-- Mail Filter -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='from' value='test1@test.com OR test2@test.com'/>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>".expandtabs(_hp.TAB_SPACING)
 
-        new_rule = Rule(["test1@test.com", "test2@test.com"])
+        new_rule = Rule(list_of_emails=["test1@test.com", "test2@test.com"])
+        new_rule.add_attribute("shouldNeverSpam", "false")
+        new_rule.add_attribute("hasTheWord", "Bla bla")
+        new_rule.add_attribute("subject", "Meow")
+        new_rule.add_attribute("doesNotHaveTheWord", "Three")
+
+        assert new_rule.final_rule_str == correct_rule
+
+    def test_rule_with_multiple_labels(self):
+        """Test whether a rule with multiple labels corretly builds
+        """
+        correct_rule = "<!-- START --- Mail Filter --- START -->\n<!-- Mail Filter (apple) -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='label' value='apple'/>\n\t<apps:property name='from' value='test1@test.com OR test2@test.com'/>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>\n<!-- Mail Filter (banana) -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='label' value='banana'/>\n\t<apps:property name='from' value='test1@test.com OR test2@test.com'/>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>\n<!-- Mail Filter (mango) -->\n<entry>\n\t<category term='filter'></category>\n\t<title>Mail Filter</title>\n\t<content></content>\n\t<apps:property name='label' value='mango'/>\n\t<apps:property name='from' value='test1@test.com OR test2@test.com'/>\n\t<apps:property name='subject' value='Meow'/>\n\t<apps:property name='hasTheWord' value='Bla bla'/>\n\t<apps:property name='doesNotHaveTheWord' value='Three'/>\n\t<apps:property name='shouldNeverSpam' value='false'/>\n</entry>\n<!-- END --- Mail Filter --- END -->".expandtabs(_hp.TAB_SPACING)
+
+        new_rule = Rule(list_of_emails=["test1@test.com", "test2@test.com"])
+        new_rule.add_attribute("label", ["apple", "banana", "mango"])
         new_rule.add_attribute("shouldNeverSpam", "false")
         new_rule.add_attribute("hasTheWord", "Bla bla")
         new_rule.add_attribute("subject", "Meow")


### PR DESCRIPTION
# Pull Request Template

## Description

This PR enables `Rule`s to have multiple labels, meaning that a single rule can be created to represent multiple rules that do the exact same thing, but apply different labels to the desired filter.  This makes it very easy to apply the same rule to emails that are in sub-folders of each other.

## Related Issues

Related to #26 
Fixes #26 

## Type of change

Please delete options that are not relevant.

- [X] New Feature (non-breaking change which adds functionality)
- [X] Documentation (added documentation or related to docs)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing a single rule with multiple labels applied to it  (`tests/test_rules/test_rule.py` --> `TestRule.test_rule_with_multiple_labels()`)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings